### PR TITLE
新規投稿のバリデーションのエラー時のrender先変更：ユーザーの使いやすさのため

### DIFF
--- a/app/controllers/public/reviews_controller.rb
+++ b/app/controllers/public/reviews_controller.rb
@@ -15,7 +15,7 @@ class Public::ReviewsController < ApplicationController
       @review.save_tags(tag_list)
       redirect_to review_path(@review), notice: "You have created review successfully."
     else
-      render 'index'
+      render :new
     end
   end
 

--- a/app/views/public/reviews/new.html.erb
+++ b/app/views/public/reviews/new.html.erb
@@ -1,3 +1,5 @@
+<%= render 'layouts/errors', obj: @review %>
+
 <div class="container-fluid basic-form text-center">
   <div class="row" >
     <div class="mx-auto">


### PR DESCRIPTION
新規投稿のバリデーションエラーが発生したとき、新規投稿画面にリダイレクトされるように修正。ユーザーの操作性を向上させるため。